### PR TITLE
Resolve RemovedInDjango30Warning deprecation warning.

### DIFF
--- a/djangoyearlessdate/models.py
+++ b/djangoyearlessdate/models.py
@@ -24,8 +24,16 @@ class YearlessDateField(models.Field):
         # The string case.
         return YearlessDate(value[2:], value[:2])
 
-    def from_db_value(self, value, expression, connection, context):
-        return self.to_python(value)
+    # 'context' argument was deprecated in Django 2.0
+    # See: https://docs.djangoproject.com/en/2.0/releases/2.0/#features-deprecated-in-2-0
+    if django.VERSION < (2,):
+
+        # TODO: remove when Django<2 support is dropped.
+        def from_db_value(self, value, expression, connection, context):
+            return self.to_python(value)
+    else:
+        def from_db_value(self, value, expression, connection):
+            return self.to_python(value)
 
     def get_prep_value(self, value):
         "The reverse of to_python, for inserting into the database"

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,2 +1,2 @@
-pytest-cov==2.5.1
-codecov==2.0.11
+pytest-cov~=2.6
+codecov~=2.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,2 @@
-pytest>=3.0
-pytest-django==3.1.2
+pytest~=4.0
+pytest-django~=3.4

--- a/tox.ini
+++ b/tox.ini
@@ -19,4 +19,4 @@ setenv=
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = tests.settings
 commands =
-    tests: py.test -v --cov=djangoyearlessdate --cov-report=term --no-cov-on-fail []
+    tests: pytest -v --cov=djangoyearlessdate --cov-report=term --no-cov-on-fail []


### PR DESCRIPTION
The 'context' argument was [deprecated in Django 2.0](https://docs.djangoproject.com/en/2.0/releases/2.0/#features-deprecated-in-2-0).

This PR adds a conditional method declaration, based on the installed Django version, to resolve the warning.

An alternative approach would be to just change the method signature to ``def from_db_value(self, value, *args, **kwargs):`` - but this version is a little more explicit and makes it clear what should be done when Django<2 support is dropped.

Also fixes pytest-django dependency that was causing tests to fail.

Use new pytest invocation format, without the dot.