### PR TITLE
Fixes has_changed flag for YearlessDateField

### DIFF
--- a/djangoyearlessdate/forms.py
+++ b/djangoyearlessdate/forms.py
@@ -36,7 +36,14 @@ class YearlessDateField(forms.Field):
                 return YearlessDate(*value)
             except:
                 raise ValidationError('Invalid date.')
-        
+
+    def has_changed(self, initial, data):
+        if data == ['', '']:
+            data = None
+        else:
+            data = YearlessDate(*data)
+        return super(YearlessDateField, self).has_changed(initial, data)    
+
 
 class YearField(forms.Field):
     widget = TextInput

--- a/djangoyearlessdate/forms.py
+++ b/djangoyearlessdate/forms.py
@@ -42,7 +42,7 @@ class YearlessDateField(forms.Field):
             data = None
         else:
             data = YearlessDate(*data)
-        return super(YearlessDateField, self).has_changed(initial, data)    
+        return super(YearlessDateField, self).has_changed(initial, data)
 
 
 class YearField(forms.Field):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -39,7 +39,7 @@ class TestYearlessDateField:
 
     def test_yearless_date_form_has_changed_value_to_new_value(self):
         form = YearlessDateForm(initial={'yearless_date': YearlessDate(29, 10)},
-                                data={'yearless_date_0': '', 'yearless_date_1': ''})
+                                data={'yearless_date_0': '18', 'yearless_date_1': '3'})
         assert form.has_changed()
 
     def test_yearless_date_form_has_not_changed_empty_to_empty(self):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -27,6 +27,29 @@ class TestYearlessDateField:
         assert not form.is_valid()
         assert form.errors['yearless_date'] == [u'This field is required.']
 
+    def test_yearless_date_form_has_not_changed(self):
+        form = YearlessDateForm(initial={'yearless_date': YearlessDate(1, 9)},
+                                data={'yearless_date_0': '1', 'yearless_date_1': '9'})
+        assert not form.has_changed()
+
+    def test_yearless_date_form_has_changed_value_to_empty(self):
+        form = YearlessDateForm(initial={'yearless_date': YearlessDate(1, 9)},
+                                data={'yearless_date_0': '', 'yearless_date_1': ''})
+        assert form.has_changed()
+
+    def test_yearless_date_form_has_changed_value_to_new_value(self):
+        form = YearlessDateForm(initial={'yearless_date': YearlessDate(29, 10)},
+                                data={'yearless_date_0': '', 'yearless_date_1': ''})
+        assert form.has_changed()
+
+    def test_yearless_date_form_has_not_changed_empty_to_empty(self):
+        form = YearlessDateForm(data={'yearless_date_0': '', 'yearless_date_1': ''})
+        assert not form.has_changed()
+
+    def test_yearless_date_form_has_changed_empty_to_new_value(self):
+        form = YearlessDateForm(data={'yearless_date_0': '1', 'yearless_date_1': '9'})
+        assert form.has_changed()
+
 
 class TestYearField:
     def test_1900_is_valid(self):


### PR DESCRIPTION
This fixes Issue #11 

This problem is manifested when using django-reversion and a model using a YearlessDateField. The YearlessDateField is currently always being marked as changed.